### PR TITLE
Remove matching against libsyntax::token::DotEq

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ impl<'a> Classifier<'a> {
             token::Lifetime(..) => Class::Lifetime,
 
             token::Eof | token::Interpolated(..) |
-            token::Tilde | token::At | token::DotEq => Class::None,
+            token::Tilde | token::At => Class::None,
         };
 
         // Anything that didn't return above is the simple case where we the


### PR DESCRIPTION
...which was removed upstream at https://github.com/rust-lang/rust/commit/96bf06baf308e5cd2ad43962895f626724395e7d