### PR TITLE
Update libsyntax api to work with nightly 1.38

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -29,14 +29,14 @@ impl<'a> fmt::Display for Escape<'a> {
         for (i, ch) in s.bytes().enumerate() {
             match ch as char {
                 '<' | '>' | '&' | '\'' | '"' => {
-                    fmt.write_str(&pile_o_bits[last.. i])?;
+                    fmt.write_str(&pile_o_bits[last..i])?;
                     let s = match ch as char {
                         '>' => "&gt;",
                         '<' => "&lt;",
                         '&' => "&amp;",
                         '\'' => "&#39;",
                         '"' => "&quot;",
-                        _ => unreachable!()
+                        _ => unreachable!(),
                     };
                     fmt.write_str(s)?;
                     last = i + 1;


### PR DESCRIPTION
Updated so it works with Rust nightly 1.38.
Tested with cargo-src which also requires a pull request. 
https://github.com/rust-dev-tools/cargo-src/pull/258